### PR TITLE
Update Exercise_10_DeployAdsWithDBServiceOnCF.md

### DIFF
--- a/ConnectDatabase/Exercise_10_DeployAdsWithDBServiceOnCF.md
+++ b/ConnectDatabase/Exercise_10_DeployAdsWithDBServiceOnCF.md
@@ -11,10 +11,10 @@ Continue with your solution of the last exercise. If this does not work, you can
 Create a service instance with name `postgres-bulletinboard-ads` on the Cloud Foundry environment. 
 
 ```
-cf create-service postgresql v9.4-dev postgres-bulletinboard-ads
+cf create-service postgresql-db development postgres-bulletinboard-ads
 ```
 
-Note: You can get the exact names of the available services and its plans in the service marketplace (`cf marketplace`). Here we have selected the service plan `v9.4-dev` for the `postgresql` service as this is a *less expensive* offering as you can also analyze in the [**SAP Business Technology Platform Cockpit**](https://account.hanatrial.ondemand.com/cockpit#/home/overview).
+Note: You can get the exact names of the available services and its plans in the service marketplace (`cf marketplace`). Here we have selected the service plan `development` for the `postgresql-db` service as this is a *less expensive* offering as you can also analyze in the [**SAP Business Technology Platform Cockpit**](https://account.hanatrial.ondemand.com/cockpit#/home/overview).
 
 Furthermore note, the created backing service is only *available* within the current targeted space and can be bound only to the applications within the same space.
 


### PR DESCRIPTION
* the old Postgres service is retired and should no longer be used
* replacing the used Postgres service by the novel Postgres Hyperscaler Option service (https://discovery-center.cloud.sap/serviceCatalog/postgresql-hyperscaler-option)